### PR TITLE
Add a test about one_if_not_zero, zero_if_not_zero and select_int

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
+dist: trusty
 language: c
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get -y install nasm
 install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
-script: bash -ex .travis-docker.sh
-services:
-  - docker
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
 env:
   global:
     - PINS="eqaf:."
-    - DISTRO="debian-stable"
   matrix:
-    - PACKAGE="eqaf" OCAML_VERSION=4.03.0 TESTS=true
-    - PACKAGE="eqaf" OCAML_VERSION=4.04.2 TESTS=true
-    - PACKAGE="eqaf" OCAML_VERSION=4.05.0 TESTS=true
-    - PACKAGE="eqaf" OCAML_VERSION=4.06.0 TESTS=true
-    - PACKAGE="eqaf" OCAML_VERSION=4.07.0 TESTS=true
-    - PACKAGE="eqaf" OCAML_VERSION=4.07.1 TESTS=true
-    - PACKAGE="eqaf" OCAML_VERSION=4.07.1 TESTS=false EXTRA_DEPS="cstruct"
-    - PACKAGE="eqaf" OCAML_VERSION=4.07.1 TESTS=false EXTRA_DEPS="base-bigarray"
+    - PACKAGE="eqaf" OCAML_VERSION=4.03 TESTS=true
+    - PACKAGE="eqaf" OCAML_VERSION=4.05 TESTS=true
+    - PACKAGE="eqaf" OCAML_VERSION=4.06 TESTS=true
+    - PACKAGE="eqaf" OCAML_VERSION=4.07 TESTS=true
+    - PACKAGE="eqaf" OCAML_VERSION=4.07 TESTS=false EXTRA_DEPS="cstruct"
+    - PACKAGE="eqaf" OCAML_VERSION=4.07 TESTS=false EXTRA_DEPS="base-bigarray"
+    - PACKAGE="eqaf" OCAML_VERSION=4.08 TESTS=true
+    - PACKAGE="eqaf" OCAML_VERSION=4.09 TESTS=true
+    - PACKAGE="eqaf" OCAML_VERSION=4.10 TESTS=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,9 @@ environment:
   - OPAM_SWITCH: 4.06.0+mingw32c
     PACKAGE: eqaf
 install:
+- curl -L -o nasminst.exe https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win32/nasm-2.14.02-installer-x86.exe
+- start /wait nasminst.exe /S
+- ps: $env:path="C:\Program Files (x86)\nasm;$($env:path)"
 - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))
 build_script:
 - call %CYG_ROOT%\bin\bash.exe -l %APPVEYOR_BUILD_FOLDER%\appveyor-opam.sh

--- a/check/check.ml
+++ b/check/check.ml
@@ -208,16 +208,25 @@ let equal () =
         Fmt.pr "> Start to compute Z.\n%!" ;
         equal_last_chance () )
 
+let compare_last_chance () =
+  let open Benchmark in
+  match ccea (V eqaf_cmp, V eqaf_ncmp) (V stdlib_cmp, V stdlib_ncmp) with
+  | Error () -> exit_failure
+  | Ok (eqaf, stdlib) ->
+    if eqaf >= -30. && eqaf <= 30.
+    then ( Fmt.pr "Z¹ = %f, Z² = %f.\n%!" eqaf stdlib ; exit_success )
+    else ( Fmt.pr "Z¹ = %f, Z² = %f.\n%!" eqaf stdlib ; exit_failure )
+
 let compare () =
   let open Benchmark in
   match spss (V eqaf_cmp, V eqaf_ncmp) (V stdlib_cmp, V stdlib_ncmp) with
-  | Error () -> equal_last_chance ()
+  | Error () -> compare_last_chance ()
   | Ok (eqaf, stdlib) ->
     if eqaf >= -30. && eqaf <= 30.
     then ( Fmt.pr "B¹ = %f, B² = %f.\n%!" eqaf stdlib ; exit_success )
     else
       ( Fmt.pr "Fail with B¹ = %f, B² = %f.\n%!" eqaf stdlib ;
-        exit_failure )
+        compare_last_chance () )
 
 let () =
   let _0 = equal () in

--- a/lib/eqaf.ml
+++ b/lib/eqaf.ml
@@ -169,3 +169,18 @@ let compare_be a b =
   if al < bl then 1
   else if al > bl then (-1)
   else compare_be ~ln:al (* = bl *) a b
+
+let[@inline always] minus_one_or_less n =
+  n lsr (Sys.int_size - 1)
+
+let[@inline always] one_if_not_zero n =
+  minus_one_or_less ((- n) lor n)
+
+let[@inline always] zero_if_not_zero n =
+  (one_if_not_zero n) - 1
+
+let[@inline always] select_int choose_b a b =
+  let mask = ((- choose_b) lor choose_b) asr Sys.int_size in
+  (a land (lnot mask)) lor (b land mask)
+
+

--- a/lib/eqaf.mli
+++ b/lib/eqaf.mli
@@ -70,3 +70,18 @@ val compare_le_with_len : len:int -> string -> string -> int
 
     @raise Invalid_argument if [len] is upper than [String.length a] or
    [String.length b]. *)
+
+val one_if_not_zero : int -> int
+(** [one_if_not_zero n] is a constant-time version of
+    [if n <> 0 then 1 else 0]. This is functionally equivalent to [!!n] in the C
+    programming language. *)
+
+val zero_if_not_zero : int -> int
+(** [zero_if_not_zero n] is a constant-time of
+    [if n <> 0 then 0 else 1]. This is functionnaly equivalent to [!n] in the C
+    programming language. *)
+
+val select_int : int -> int -> int -> int
+(** [select_int choose_b a b] is [a] if [choose_b = 0] and [b] otherwise.
+    This comparison is constant-time and it should not be possible for a measuring
+    adversary to determine anything about the values of [choose_b], [a], or [b]. *)

--- a/test/asm_sleep.S
+++ b/test/asm_sleep.S
@@ -1,0 +1,15 @@
+global eqaf_sleep
+
+section .data
+  timespec:
+    tv_sec  dq 1
+    tv_nsec dq 0
+
+section .text
+  eqaf_sleep:
+    mov rax, 35
+    mov rdi, timespec
+    xor rsi, rsi
+    syscall
+    mov rax, 0
+    ret

--- a/test/build.sh
+++ b/test/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+nasm -felf64 asm_sleep.S
+ocamlopt -c test_branch.ml
+ocamlopt asm_sleep.o time.c test_branch.ml -o test_branch

--- a/test/dune
+++ b/test/dune
@@ -6,3 +6,13 @@
  (name runtest)
  (deps (:test test.exe))
  (action (run %{test} --color=always)))
+
+(rule
+ (targets test_branch)
+ (deps build.sh (:src asm_sleep.S time.c test_branch.ml))
+ (action (run ./build.sh)))
+
+(alias
+ (name runtest)
+ (deps (:test test_branch))
+ (action (run %{test})))

--- a/test/test_branch.ml
+++ b/test/test_branch.ml
@@ -1,0 +1,112 @@
+let exit_success = 0
+let exit_failure = 1
+
+let operation = ref 0
+
+let logical_shift_right a b = incr operation ; a lsr b
+let logical_or a b = incr operation ; a lor b
+let shift_right a b = incr operation ; a asr b
+let logical_and a b = incr operation ; a land b
+let logical_not a = incr operation ; lnot a
+let minus a = incr operation ; (- a)
+let sub a b = incr operation ; a - b
+
+let[@inline always] minus_one_or_less n =
+  logical_shift_right n (sub Sys.int_size 1)
+
+let[@inline always] one_if_not_zero n = minus_one_or_less (logical_or (minus n) n)
+let[@inline always] zero_if_not_zero n = sub (one_if_not_zero n) 1
+let[@inline always] select_int choose_b a b =
+  let mask = shift_right (logical_or (minus choose_b) choose_b) Sys.int_size in
+  logical_or (logical_and a (logical_not mask)) (logical_and b mask)
+
+let one_if_not_zero_ops =
+  let _ = one_if_not_zero 0xdeadbeef in
+  Format.printf "[one_if_not_zero]:             %d operation(s).\n%!" !operation ;
+  !operation
+
+let () = operation := 0
+
+let zero_if_not_zero_ops =
+  let _ = zero_if_not_zero 0xdeadbeef in
+  Format.printf "[zero_if_not_zero]:            %d operation(s).\n%!" !operation ;
+  !operation
+
+let () = operation := 0
+
+let select_int_ops =
+  let _ = select_int 0 1 2 in
+  Format.printf "[select_int]:                  %d operation(s).\n%!" !operation ;
+  !operation
+
+external eqaf_sleep : unit -> unit = "eqaf_sleep" [@@noalloc]
+
+let logical_shift_right a b = eqaf_sleep () ; a lsr b
+let logical_or a b = eqaf_sleep () ; a lor b
+let shift_right a b = eqaf_sleep () ; a asr b
+let logical_and a b = eqaf_sleep () ; a land b
+let logical_not a = eqaf_sleep () ; lnot a
+let minus a = eqaf_sleep () ; (- a)
+let sub a b = eqaf_sleep () ; a - b
+
+let[@inline always] minus_one_or_less n =
+  logical_shift_right n (sub Sys.int_size 1)
+
+let[@inline always] one_if_not_zero n = minus_one_or_less (logical_or (minus n) n)
+let[@inline always] zero_if_not_zero n = sub (one_if_not_zero n) 1
+let[@inline always] select_int choose_b a b =
+  let mask = shift_right (logical_or (minus choose_b) choose_b) Sys.int_size in
+  logical_or (logical_and a (logical_not mask)) (logical_and b mask)
+
+external time : unit -> (int64 [@unboxed]) = "caml_time_bytes" "caml_time" [@@noalloc]
+
+let fdiv a b = a /. b
+
+let () =
+  let t0 = time () in
+  let _  = one_if_not_zero 0xdeadbeef in
+  let t1 = time () in
+  let v0 = Int64.(floor (fdiv (to_float (sub t1 t0)) 1000000000.)) in
+  Format.printf "[one_if_not_zero 0xdeadbeef]:  %fs.\n%!" v0 ;
+  let t0 = time () in
+  let _  = one_if_not_zero 0x0 in
+  let t1 = time () in
+  let v1 = Int64.(floor (fdiv (to_float (sub t1 t0)) 1000000000.)) in
+  Format.printf "[one_if_not_zero 0x0]:         %fs.\n%!" v0 ;
+  if v0 = v1
+  && int_of_float v0 = one_if_not_zero_ops
+  && int_of_float v1 = one_if_not_zero_ops
+  then () else exit exit_failure
+
+let () =
+  let t0 = time () in
+  let _  = zero_if_not_zero 0xdeadbeef in
+  let t1 = time () in
+  let v0 = Int64.(floor (fdiv (to_float (sub t1 t0)) 1000000000.)) in
+  Format.printf "[zero_if_not_zero 0xdeadbeef]: %fs.\n%!" v0 ;
+  let t0 = time () in
+  let _  = zero_if_not_zero 0x0 in
+  let t1 = time () in
+  let v1 = Int64.(floor (fdiv (to_float (sub t1 t0)) 1000000000.)) in
+  Format.printf "[zero_if_not_zero 0x0]:        %fs.\n%!" v0 ;
+  if v0 = v1
+  && int_of_float v0 = zero_if_not_zero_ops
+  && int_of_float v1 = zero_if_not_zero_ops
+  then () else exit exit_failure
+
+let () =
+  let t0 = time () in
+  let _  = select_int 0 1 2 in
+  let t1 = time () in
+  let v0 = Int64.(floor (fdiv (to_float (sub t1 t0)) 1000000000.)) in
+  Format.printf "[select_int 0 1 2]:            %fs.\n%!" v0  ;
+  let t0 = time () in
+  let _  = select_int 2 1 0 in
+  let t1 = time () in
+  let v1 = Int64.(floor (fdiv (to_float (sub t1 t0)) 1000000000.)) in
+  Format.printf "[select_int 2 1 0]:            %fs.\n%!" v1 ;
+  if v0 = v1
+  && int_of_float v0 = select_int_ops
+  && int_of_float v1 = select_int_ops
+  then () else exit exit_failure
+;;

--- a/test/time.c
+++ b/test/time.c
@@ -1,0 +1,24 @@
+#include <caml/memory.h>
+#include <caml/fail.h>
+
+#include <time.h>
+
+#define __unused(x) x __attribute((unused))
+#define __unit() value __unused(unit)
+
+CAMLprim value
+caml_rdtsc(__unit ())
+{
+  unsigned hi, lo;
+  __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
+  return Val_int(((unsigned long long) lo) | (((unsigned long long) hi) << 32));
+}
+
+uint64_t
+caml_time(__unit ())
+{
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts))
+    caml_invalid_argument("caml_time");
+  return ((uint64_t) ts.tv_sec * (uint64_t) 1000000000LL + (uint64_t) ts.tv_nsec); 
+}


### PR DESCRIPTION
The code comes from @cfcs and try to check if:
* `one_if_not_zero`
* `zero_if_not_zero`
* `select_int`
Compute inputs in constant-time.

The test can be executed by `dune exec test/test_branch`. It consists to:
1) count how many operations we need to compute inputs
2) _hijack_ operations with a `sleep` of 1s (see `asm_sleep.S`)
3) compute function and get how many times we spend
4) round the time to the second (`Float.floor`)
5) compare time needed for first kind of inputs and second kind of inputs
6) compare time needed with how many operations we counted before

Output of this test is like:
```sh
$ dune exec bin/test_branch
[one_if_not_zero]:             4 operation(s).
[zero_if_not_zero]:            5 operation(s).
[select_int]:                  7 operation(s).
[one_if_not_zero 0xdeadbeef]:  4.000000s.
[one_if_not_zero 0x0]:         4.000000s.
[zero_if_not_zero 0xdeadbeef]: 5.000000s.
[zero_if_not_zero 0x0]:        5.000000s.
[select_int 0 1 2]:            7.000000s.
[select_int 2 1 0]:            7.000000s.
```