### PR TITLE
Add some utility functions

### DIFF
--- a/check/check.ml
+++ b/check/check.ml
@@ -360,7 +360,7 @@ module Find = Make(struct
   let reset () = ()
 
   let stdlib_true () = String.index hash_eq_0 chr_into_hash_eq_0
-  let stdlib_false () = String.index hash_neq_0 random_chr
+  let stdlib_false () = try String.index hash_neq_0 random_chr with Not_found -> (-1)
 
   let f_hash_eq_0 (v : int) = v = Char.code chr_into_hash_eq_0
   let f_random (v : int) = v = Char.code random_chr

--- a/check/check.ml
+++ b/check/check.ml
@@ -41,14 +41,14 @@ let hash_eq_0 = random 4096
 let hash_eq_1 = Bytes.to_string (Bytes.of_string hash_eq_0)
 let chr_into_hash_eq_0 = hash_eq_0.[Random.int 4096]
 let int32_into_hash_eq_0 =
-  Bytes.get_int32_ne (Bytes.of_string hash_eq_0) (Random.int (4096-4))
+  Unsafe.get_int32_ne (Bytes.of_string hash_eq_0) (Random.int (4096-4))
 let int32_into_hash_eq_1 =
-  Bytes.get_int32_ne (Bytes.of_string hash_eq_1) (Random.int (4096-4))
+  Unsafe.get_int32_ne (Bytes.of_string hash_eq_1) (Random.int (4096-4))
 let int14_into_hash_eq_0 =
-  Bytes.get_int32_ne (Bytes.of_string hash_eq_0) (Random.int (4096-4))
+  Unsafe.get_int32_ne (Bytes.of_string hash_eq_0) (Random.int (4096-4))
   |> (Int32.logand 0xfffl)
 let int14_into_hash_eq_1 =
-  Bytes.get_int32_ne (Bytes.of_string hash_eq_1) (Random.int (4096-4))
+  Unsafe.get_int32_ne (Bytes.of_string hash_eq_1) (Random.int (4096-4))
   |> (Int32.logand 0xfffl)
 
 let () = assert (hash_eq_0 != hash_eq_1)

--- a/check/check.ml
+++ b/check/check.ml
@@ -40,6 +40,16 @@ let random length =
 let hash_eq_0 = random 4096
 let hash_eq_1 = Bytes.to_string (Bytes.of_string hash_eq_0)
 let chr_into_hash_eq_0 = hash_eq_0.[Random.int 4096]
+let int32_into_hash_eq_0 =
+  Bytes.get_int32_ne (Bytes.of_string hash_eq_0) (Random.int (4096-4))
+let int32_into_hash_eq_1 =
+  Bytes.get_int32_ne (Bytes.of_string hash_eq_1) (Random.int (4096-4))
+let int14_into_hash_eq_0 =
+  Bytes.get_int32_ne (Bytes.of_string hash_eq_0) (Random.int (4096-4))
+  |> (Int32.logand 0xfffl)
+let int14_into_hash_eq_1 =
+  Bytes.get_int32_ne (Bytes.of_string hash_eq_1) (Random.int (4096-4))
+  |> (Int32.logand 0xfffl)
 
 let () = assert (hash_eq_0 != hash_eq_1)
 let () = assert (hash_eq_0 = hash_eq_1)
@@ -340,6 +350,64 @@ module Exists = Make(struct
   let eqaf_false () = Eqaf.exists_uint8 ~f hash_neq_0
 end)
 
+module Find = Make(struct
+  type ret = int
+
+  let eqaf_name = "Eqaf.find_uint8"
+  let stdlib_name = "String.index"
+
+
+  let stdlib_true () = String.index hash_eq_0 chr_into_hash_eq_0
+  let stdlib_false () = String.index hash_neq_0 random_chr
+
+  let f_hash_eq_0 (v : int) = v = Char.code chr_into_hash_eq_0
+  let f_random (v : int) = v = Char.code random_chr
+  let eqaf_true () = Eqaf.find_uint8 ~f:f_hash_eq_0 hash_eq_0
+  let eqaf_false () = Eqaf.find_uint8 ~f:f_random hash_neq_0
+end)
+
+module Divmod32 = Make(struct
+  type ret = int32 * int32
+
+  let eqaf_name = "Eqaf.divmod"
+  let stdlib_name = "Int32.unsigned_div,Int32.unsigned_rem"
+
+  (* TODO *)
+  let stdlib_true () =
+    let x, m = int32_into_hash_eq_0, int14_into_hash_eq_0 in
+    Int32.unsigned_div x m,
+    Int32.unsigned_rem x m
+  let stdlib_false () =
+    let x, m = int32_into_hash_eq_1, int14_into_hash_eq_1 in
+    Int32.unsigned_div x m,
+    Int32.unsigned_rem x m
+
+  let eqaf_true () =
+    Eqaf.divmod ~x:int32_into_hash_eq_0 ~m:int14_into_hash_eq_0
+  let eqaf_false () =
+    Eqaf.divmod ~x:int32_into_hash_eq_1 ~m:int14_into_hash_eq_1
+end)
+
+module Ascii_int32 = Make(struct
+  type ret = string
+
+  let eqaf_name = "Eqaf.ascii_of_int32"
+  let stdlib_name = "Int32.to_string"
+
+  (* TODO setting 0x8000 bit ensures five digits.
+     We need a constant amount of digits to specify ~digits because
+     we don't have a [Int32.to_string] that left-pads.
+     Maybe we can use [Format.sprintf] ?
+  *)
+  let true_int = Int32.logand 0x8000l int14_into_hash_eq_0
+  let false_int = Int32.logand 0x8000l int14_into_hash_eq_1
+  let stdlib_true () = Int32.to_string true_int
+  let stdlib_false () = Int32.to_string false_int
+
+  let eqaf_true () = Eqaf.ascii_of_int32 ~digits:5 true_int
+  let eqaf_false () = Eqaf.ascii_of_int32 ~digits:5 false_int
+end)
+
 let limit = 20
 
 let () =
@@ -355,6 +423,14 @@ let () =
     if tried > 20 then invalid_arg "Too many tried for Eqaf.exists" ;
     let res = Exists.test () in
     if res = exit_success then tried else _2 (succ tried) in
+  let rec _3 tried =
+    if tried > 20 then invalid_arg "Too many tried for Eqaf.find_uint8" ;
+    let res = Find.test () in
+    if res = exit_success then tried else _3 (succ tried) in
+  let rec _4 tried =
+    if tried > 20 then invalid_arg "Too many tried for Eqaf.divmod" ;
+    let res = Divmod32.test () in
+    if res = exit_success then tried else _4 (succ tried) in
 
   let _0 = _0 1 in
   Fmt.pr "%d trial(s) for Eqaf.equal.\n%!" _0 ;
@@ -362,5 +438,9 @@ let () =
   Fmt.pr "%d trial(s) for Eqaf.compare.\n%!" _1 ;
   let _2 = _2 1 in
   Fmt.pr "%d trial(s) for Eqaf.exists.\n%!" _2 ;
+  let _3 = _3 1 in
+  Fmt.pr "%d trial(s) for Eqaf.find_uint8.\n%!" _3 ;
+  let _4 = _4 1 in
+  Fmt.pr "%d trial(s) for Eqaf.divmod.\n%!" _3 ;
 
   exit exit_success

--- a/check/dune
+++ b/check/dune
@@ -3,6 +3,9 @@
  (libraries eqaf base64 clock))
 
 (rule
+ (copy %{read:../config/which-unsafe-file} unsafe.ml))
+
+(rule
  (alias runtest)
  (deps
   (:check check.exe))

--- a/check/unsafe_pre407.ml
+++ b/check/unsafe_pre407.ml
@@ -1,0 +1,1 @@
+external get_int32_ne : bytes -> int -> int32 = "%caml_string_get32"

--- a/check/unsafe_pre408.ml
+++ b/check/unsafe_pre408.ml
@@ -1,0 +1,1 @@
+external get_int32_ne : bytes -> int -> int32 = "%caml_bytes_get32"

--- a/check/unsafe_stable.ml
+++ b/check/unsafe_stable.ml
@@ -1,0 +1,1 @@
+let get_int32_ne b i = Bytes.get_int32_ne b i

--- a/config/config.ml
+++ b/config/config.ml
@@ -1,0 +1,10 @@
+let parse s = Scanf.sscanf s "%d.%d" (fun major minor -> (major, minor))
+
+let () =
+  let version = parse Sys.ocaml_version in
+  if version >= (4, 8)
+  then print_string "unsafe_stable.ml"
+  else if version >= (4, 7)
+  then print_string "unsafe_pre408.ml"
+  else print_string "unsafe_pre407.ml"
+

--- a/config/dune
+++ b/config/dune
@@ -1,0 +1,7 @@
+(executable
+ (name config))
+
+(rule
+ (with-stdout-to
+  which-unsafe-file
+  (run ./config.exe)))

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -1,6 +1,67 @@
 open Crowbar
 
 let () =
+  add_test ~name:"select_a_if_in_range"
+    [ range max_int ; range max_int ; int; range 10000; range 10000 ]
+  @@ fun low high n a b ->
+  let low, high = min low high, max low high in
+  let choice = Eqaf.select_a_if_in_range ~low ~high ~n a b in
+  check_eq ~eq:(=) (if low <= n && n <= high then a else b) choice
+
+let () =
+  add_test ~name:"divmod" [ int32 ; int32 ]
+  @@ fun x m ->
+  try
+    let result = Eqaf.divmod ~x ~m in
+    let expect = Int32.unsigned_div x m,
+                 Int32.unsigned_rem x m in
+    check_eq ~eq:(=) expect result
+  with
+  | Invalid_argument desc ->
+    (* we expect this for negative m: *)
+    assert (desc = "m <= 0" || desc = "m >= 16348 not supported")
+
+let () =
+  add_test ~name:"hex_of_string |> string_of_hex" [ bytes ]
+  @@ fun raw ->
+  let enc = Eqaf.hex_of_string raw in
+  let dec = Eqaf.string_of_hex enc in
+  check_eq ~pp:(fun fmt s -> Format.pp_print_string fmt @@ String.escaped s)
+    ~eq:(=) raw dec ;
+  String.iter (function (* check for invalid encoding: *)
+      | '0'..'9'
+      | 'a'..'z'
+      | 'A'..'Z' -> ()
+      | _ -> assert false) enc
+
+let () =
+  add_test ~name:"string_of_hex |> hex_of_string" [ bytes ]
+  @@ fun hex ->
+  begin
+    try begin
+      let dec = Eqaf.string_of_hex hex in
+      let enc = Eqaf.hex_of_string dec in
+      check_eq ~pp:(fun fmt s -> Format.pp_print_string fmt @@ String.escaped s)
+        ~eq:(=) (String.lowercase_ascii hex) enc ;
+    end
+    with Invalid_argument x ->
+      let invalid = ref false in
+      begin
+        if (String.length hex mod 2 = 1)
+        && x = "hex length must be multiple of 2" then begin
+          invalid := true
+        end else begin if x = "decoding invalid hex" then
+            String.iter (function
+                | 'a'..'f'
+                | '0'..'9'
+                | 'A'..'F' -> ()
+                | _ -> invalid := true
+              ) hex ;
+        end ;
+      end ; assert !invalid (* we expect it to be invalid since it raised *)
+  end
+
+let () =
   add_test ~name:"equal" [ bytes; bytes; ] @@ fun a b ->
   let expect = String.equal a b in
   let result = Eqaf.equal a b in

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -1,6 +1,12 @@
 open Crowbar
 
 let () =
+  add_test ~name:"bool_of_int" [ int ]
+  @@ fun n ->
+  let result = Eqaf.bool_of_int n in
+  check_eq ~eq:(=) (if n = 0 then false else true) result
+
+let () =
   add_test ~name:"select_a_if_in_range"
     [ range max_int ; range max_int ; int; range 10000; range 10000 ]
   @@ fun low high n a b ->

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -15,6 +15,20 @@ let () =
   check_eq ~eq:(=) (if low <= n && n <= high then a else b) choice
 
 let () =
+  add_test ~name:"uppercase_ascii" [ bytes ]
+  @@ fun raw_str ->
+  check_eq ~eq:String.equal
+    (String.uppercase_ascii raw_str)
+    (Eqaf.uppercase_ascii raw_str)
+
+let () =
+  add_test ~name:"lowercase_ascii" [ bytes ]
+  @@ fun raw_str ->
+  check_eq ~eq:String.equal
+    (String.lowercase_ascii raw_str)
+    (Eqaf.lowercase_ascii raw_str)
+
+let () =
   add_test ~name:"divmod" [ int32 ; int32 ]
   @@ fun x m ->
   try

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,10 @@
 (library
  (name eqaf)
  (public_name eqaf)
- (modules eqaf))
+ (modules unsafe eqaf))
+
+(rule
+ (copy %{read:../config/which-unsafe-file} unsafe.ml))
 
 (library
  (name eqaf_bigstring)

--- a/lib/eqaf.ml
+++ b/lib/eqaf.ml
@@ -240,8 +240,8 @@ let divmod ~(x:int32) ~(m:int32) : int32 * int32 =
   let of_uint32 uint =
     (* apparently Int64.of_int32 sign-extends ... great... avoid that: *)
     let b = Bytes.make 8 '\x00' in
-    Bytes.set_int32_le b 0 uint ;
-    Bytes.get_int64_le b 0
+    Unsafe.set_int32_le b 0 uint ;
+    Unsafe.get_int64_le b 0
   in
 
   let x_0 = x in

--- a/lib/eqaf.ml
+++ b/lib/eqaf.ml
@@ -311,34 +311,6 @@ let hex_of_string rawbytes =
 
 let hex_of_bytes rawbytes = hex_of_string (Bytes.unsafe_to_string rawbytes)
 
-let[@inline always] lowercase_hex_nibble_to_int ch : int =
-  (* converts [0-9af] to [int] in range [0-15].
-     NB: THIS FUNCTION DOES NOT HANDLE UPPERCASE [A-F] AND DOES NO
-         ERROR DETECTION. ONLY WORKS FOR [0-9a-f] - but then it's fast :-)
-  *)
-  (* camlExample__nibble_to_int_1199:
-        addq    $-32, %rax
-        andq    $-65, %rax
-        movq    %rax, %rbx
-        andq    $45, %rbx
-        shrq    $4, %rbx
-        orq     $1, %rbx
-        imulq   $71, %rbx
-        subq    %rbx, %rax
-        addq    $71, %rax
-        ret
-  *)
-  let x =
-    let x =
-      let i = Char.code ch in
-      (i + 39 - 1 - 54) in
-    x land (lnot 0x20) in
-  x - (((x land 0x16) lsr 4) * 71)
-let _ =
-  (* ended up not using this because error detection was nicer,
-     if a bit slower. *)
-  lowercase_hex_nibble_to_int
-
 let[@inline always] select_a_if_in_range ~low ~high ~n a b =
   (* select [a] if [low <= n <= high] and [b] if [n] is out of range.*)
   (* NB: ONLY WORKS FOR [0 <= low <= high <= max_int]*)

--- a/lib/eqaf.ml
+++ b/lib/eqaf.ml
@@ -1,3 +1,8 @@
+let[@inline always] char_chr ch =
+  (* Char.chr contains a branch on [ch] and a plt indirection, this
+   * implementation ensures well-formedness by construction and avoids that: *)
+  Char.unsafe_chr (ch land 0xff)
+
 let[@inline] get x i = String.unsafe_get x i |> Char.code
 
 (* XXX(dinosaure): we use [unsafe_get] to avoid jump to exception:
@@ -186,6 +191,9 @@ let[@inline always] select_int choose_b a b =
 external int_of_bool : bool -> int = "%identity"
 external unsafe_bool_of_int : int -> bool = "%identity"
 
+let[@inline] bool_of_int n =
+  unsafe_bool_of_int (one_if_not_zero n)
+
 let[@inline always] find_uint8 ~off ~len ~f str =
   let i = ref (len - 1) in
   let a = ref (lnot 0) in
@@ -212,3 +220,180 @@ let exists_uint8 ?off ~f str =
   let v = find_uint8 ?off ~f str in
   let r = select_int (v + 1) 0 1 in
   unsafe_bool_of_int r
+
+let divmod ~(x:int32) ~(m:int32) : int32 * int32 =
+  (* Division and remainder being constant-time with respect to [x]
+   * ( NOT [m] !). The OCaml variant would be:
+   * [(x / m , x mod m)] where [x] is a secret and [m] is not secret.
+   * Adapted from the NTRU Prime team's algorithm from
+   * supercop/crypto_kem/sntrup761/ref/uint32.c
+   * cite the round-2 ntru prime submission to nistpqc (march 2019)
+   * Note that in practice this works for at least some much larger [x] and [m],
+   * but it's unclear to me how to evaluate *which*, so leaving the original
+   * restrictions in.
+  *)
+  let ( - ) , ( + ), ( * ) = Int32.(sub, add, mul) in
+  let ( >> ) = Int32.shift_right_logical in
+  if (m <= 0l) then raise (Invalid_argument "m <= 0") ;
+  if (m >= 16348l) then raise (Invalid_argument "m >= 16348 not supported") ;
+
+  let of_uint32 uint =
+    (* apparently Int64.of_int32 sign-extends ... great... avoid that: *)
+    let b = Bytes.make 8 '\x00' in
+    Bytes.set_int32_le b 0 uint ;
+    Bytes.get_int64_le b 0
+  in
+
+  let x_0 = x in
+
+  let x_2, q_1 =
+    let v = Int32.unsigned_div Int32.min_int m |> of_uint32 in
+    (*let v = 0x80_00_00_00 / m in*) (* floored div *)
+    let x_1, q_0 =
+      let qpart_0 =
+        let open Int64 in
+        shift_right_logical (mul (of_uint32 x_0) v) 31
+        |> to_int32
+      in
+      x_0 - (qpart_0 * m), qpart_0
+    in
+    let qpart_1 =
+      let open Int64 in
+      shift_right_logical (mul (of_uint32 x_1) v) 31
+      |> to_int32 in
+    x_1 - (qpart_1 * m),
+    (q_0 + qpart_1 + 1l) in
+  let x_3 = x_2 - m  in
+  let mask = 0l - (x_3 >> 31) in
+  q_1 + mask, x_3 + (Int32.logand mask m)
+
+let ascii_of_int32 ~digits (n:int32) : string =
+  (* Recursively calls [divmod n 10]; the remainder is turned into ASCII
+     and the quotient is used for the next division.*)
+  if digits < 0 then raise (Invalid_argument "digits < 0");
+  let out = Bytes.make digits '0' in
+  let rec loop x = function
+    | -1 -> Bytes.unsafe_to_string out
+    | idx ->
+      let next, this = divmod ~x ~m:10l in
+      Bytes.set out idx @@ char_chr (0x30 lor (Int32.to_int this)) ;
+      loop next (pred idx)
+  in loop n (pred digits)
+
+let[@inline always] to_hex_nibble f : char =
+  let a = 86 + f in
+  let c = 1 + ((a - 71 * ((a land 0x10) lsr 4)) lor 0x20) in
+  char_chr c
+
+let hex_of_string rawbytes =
+  String.init (2 * String.length rawbytes)
+    (fun idx ->
+       let byt = String.get rawbytes (idx lsr 1) |> Char.code in
+       (* select which 4 bits to use, this can probably be done faster:*)
+       let nib = 0xf land (byt lsr (((lnot idx) land 1) lsl 2)) in
+       to_hex_nibble nib)
+
+let hex_of_bytes rawbytes = hex_of_string (Bytes.unsafe_to_string rawbytes)
+
+let[@inline always] lowercase_hex_nibble_to_int ch : int =
+  (* converts [0-9af] to [int] in range [0-15].
+     NB: THIS FUNCTION DOES NOT HANDLE UPPERCASE [A-F] AND DOES NO
+         ERROR DETECTION. ONLY WORKS FOR [0-9a-f] - but then it's fast :-)
+  *)
+  (* camlExample__nibble_to_int_1199:
+        addq    $-32, %rax
+        andq    $-65, %rax
+        movq    %rax, %rbx
+        andq    $45, %rbx
+        shrq    $4, %rbx
+        orq     $1, %rbx
+        imulq   $71, %rbx
+        subq    %rbx, %rax
+        addq    $71, %rax
+        ret
+  *)
+  let x =
+    let x =
+      let i = Char.code ch in
+      (i + 39 - 1 - 54) in
+    x land (lnot 0x20) in
+  x - (((x land 0x16) lsr 4) * 71)
+let _ =
+  (* ended up not using this because error detection was nicer,
+     if a bit slower. *)
+  lowercase_hex_nibble_to_int
+
+let[@inline always] select_a_if_in_range ~low ~high ~n a b =
+  (* select [a] if [low <= n <= high] and [b] if [n] is out of range.*)
+  (* NB: ONLY WORKS FOR [0 <= low <= high <= max_int]*)
+  (* The idea being that:
+     1.a) if low <=   n : (n - low)  is positive +
+     1.b) if low  >   n : (n - low)  is negative -
+     2.a) if   n <= high: (high - n) is positive +
+     2.b) if   n  > high: (high - n) is negative -
+     We OR the numbers together; we only really care about the sign bit
+     which is set when negative.
+     Thus both numbers are positive iff (low <= n && n <= high).
+     We then select the sign bit with (land min_int) and use that to choose:
+  *)
+  let out_of_range = (* choose b if out of range *)
+    ((n - low) lor (high - n)
+     land min_int)
+  in
+  select_int out_of_range a b
+
+let lowercase_ascii src =
+  (* ct version of String.lowercase_ascii *)
+  String.map
+    ( fun ch -> let n = Char.code ch in
+      select_a_if_in_range ~low:0x41 ~high:0x5a ~n (n lor 0x20) (n)
+      |> char_chr
+    ) src
+
+let uppercase_ascii src =
+  (* ct version of String.uppercase_ascii *)
+  String.map
+    ( fun ch -> let n = Char.code ch in
+      select_a_if_in_range ~low:0x61 ~high:0x7a ~n (n lxor 0x20) (n)
+      |> char_chr
+    ) src
+
+let bytes_of_hex rawhex =
+  if 1 land (String.length rawhex) = 1 then
+    raise (Invalid_argument "hex length must be multiple of 2");
+  let error_bitmap = ref 0 in
+  let decoded =
+    Bytes.init (String.length rawhex lsr 1)
+      (fun idx ->
+         let idx = idx lsl 1 in
+         let nib idx =
+           String.get rawhex idx
+           |> Char.code
+           |> fun n -> (* uppercase -> lowercase: *)
+           select_a_if_in_range ~low:0x41 ~high:0x5a
+             ~n
+             (n lor 0x20) (* set case bit *)
+             n (* leave as-is *)
+           |> fun n -> (* now either invalid; lowercase; numeric*)
+           (select_a_if_in_range ~low:0x30 ~high:0x39
+              ~n
+              (n - 0x30) (* numeric: subtract '0' to get [0..9] *)
+              (select_a_if_in_range ~low:0x61 ~high:0x66
+                 ~n
+                 (* a-f: subtract 'a' and add 10 to get [10..15]: *)
+                 (n - 0x61 + 10)
+                 (0xff) (* invalid, ensure we set upper bits of error_bitmap *)
+              )
+           )
+         in
+         let nibf0 = nib idx
+         and nib0f = nib (succ idx) in
+         error_bitmap := !error_bitmap lor nibf0 lor nib0f ;
+         char_chr ((nibf0 lsl 4) lor nib0f)
+      )
+  in
+  if !error_bitmap land 0xf0 <> 0
+  then raise (Invalid_argument "decoding invalid hex")
+  else decoded
+
+let string_of_hex rawhex = Bytes.unsafe_to_string (bytes_of_hex rawhex)

--- a/lib/eqaf.ml
+++ b/lib/eqaf.ml
@@ -346,6 +346,7 @@ let lowercase_ascii src =
   (* ct version of String.lowercase_ascii *)
   String.map
     ( fun ch -> let n = Char.code ch in
+      (* 0x41 is 'A'; 0x5a is 'Z'; 0x20 controls case for ASCII letters *)
       select_a_if_in_range ~low:0x41 ~high:0x5a ~n (n lor 0x20) (n)
       |> char_chr
     ) src
@@ -354,6 +355,7 @@ let uppercase_ascii src =
   (* ct version of String.uppercase_ascii *)
   String.map
     ( fun ch -> let n = Char.code ch in
+      (* 0x61 is 'a'; 0x7a is 'z'; 0x20 controls case for ASCII letters *)
       select_a_if_in_range ~low:0x61 ~high:0x7a ~n (n lxor 0x20) (n)
       |> char_chr
     ) src

--- a/lib/eqaf.ml
+++ b/lib/eqaf.ml
@@ -247,7 +247,23 @@ let divmod ~(x:int32) ~(m:int32) : int32 * int32 =
   let x_0 = x in
 
   let x_2, q_1 =
-    let v = Int32.unsigned_div Int32.min_int m |> of_uint32 in
+    let int32_div_unsigned n d =
+      (* can be replaced by Int32.unsigned_div
+       * from OCaml >= 4.10 *)
+      let sub,min_int = Int32.(sub,min_int)in
+      let int32_unsigned_compare n m =
+        Int32.compare (sub n min_int) (sub m min_int)
+      in
+      if d < 0_l then
+        if int32_unsigned_compare n d < 0 then 0_l else 1_l
+      else
+        let q =
+          let open Int32 in
+          shift_left (Int32.div (Int32.shift_right_logical n 1) d) 1 in
+        let r = sub n (Int32.mul q d) in
+        if int32_unsigned_compare r d >= 0 then Int32.succ q else q
+    in
+    let v = int32_div_unsigned Int32.min_int m |> of_uint32 in
     (*let v = 0x80_00_00_00 / m in*) (* floored div *)
     let x_1, q_0 =
       let qpart_0 =

--- a/lib/eqaf.mli
+++ b/lib/eqaf.mli
@@ -1,6 +1,6 @@
-(** Eqaf - timing-safe comparison functions
+(** Eqaf - constant time / timing side channel resistant functions *)
 
-    {1 Basics}
+(** {1 Basics}
 
     In cryptography, a timing-attack is a side-channel attack in which the
    attacker attempts to compromise a cryptosystem by analyzing the time taken to
@@ -17,7 +17,7 @@
 
     Distribution provides a little example of this kind of attack where we
    construct step by step (byte per byte) expected value from time spended to
-   execute [compare].
+   execute {!Stdlib.compare}.
 
     Distribution wants to provide some functions which protect user against this
    kind of attack:
@@ -26,17 +26,22 @@
     {- [equal] like {!String.equal}}
     {- [compare_be] like {!String.compare}}
     {- [compare_le] which is a {!String.compare} with a reverse operation on
-   inputs}}
+   inputs}
+    {- {!divmod} like {!Int32.unsigned_div} and {!Int32.unsigned_rem}}}
 
     These functions are tested to see how long they took to compare two equal
    values and two different values. See {i check} tool for more informations. *)
 
-(** {2 Implementations} *)
+(** {1 Comparison functions} *)
+
+(** {2 Equal} *)
 
 val equal : string -> string -> bool
 (** [equal a b] returns [true] if [a] and [b] are equals. [String.equal a b =
    equal a b] for any [a] and [b]. The execution time of [equal] depends solely
    on the length of the strings, not the contents. *)
+
+(** {2 Big-endian comparison} *)
 
 val compare_be : string -> string -> int
 (** [compare_be a b] returns [0] if [a] is equal to [b], a negative integer if
@@ -55,14 +60,17 @@ val compare_be : string -> string -> int
    look into [a] or [b] and no comparison in bytes will be done. *)
 
 val compare_be_with_len : len:int -> string -> string -> int
-(** [compare_be_with_len ~len a b] does {!compare_be a b} on [len] bytes.
+(** [compare_be_with_len ~len a b] does {!compare_be}[ a b] on [len] bytes.
 
     @raise Invalid_argument if [len] is upper than [String.length a] or
    [String.length b]. *)
 
+(** {2 Little-endian comparison} *)
+
 val compare_le : string -> string -> int
-(** [compare_le a b] is semantically [compare_be (rev a) (rev b)]. With [rev]
-   reverses a string ([a = rev (rev a)]). *)
+(** [compare_le a b] is semantically [compare_be (rev a) (rev b)],
+    where [rev] is a function that reverses a string bytewise
+    ([a = rev (rev a)]). *)
 
 val compare_le_with_len : len:int -> string -> string -> int
 (** [compare_le_with_len a b] is semantically [compare_be_with_len ~len (rev a)
@@ -70,6 +78,136 @@ val compare_le_with_len : len:int -> string -> string -> int
 
     @raise Invalid_argument if [len] is upper than [String.length a] or
    [String.length b]. *)
+
+(** {1 Arithmetic} *)
+
+(** {2 Division} *)
+
+val divmod : x:int32 -> m:int32 -> int32 * int32
+(** 32-bit unsigned division with remainder,
+    constant-time with respect to [x] ({b not} [m]).
+
+    @param x Dividend (number to be divided). {b Can be secret}.
+    @param m Divisor  {b Must not be secret}. Must be [0 < m < 16384]
+
+    This function is useful for implementation that need to produce e.g.
+    pincodes from binary values in int32 format, example: {!ascii_of_int32}.
+
+    @return [quotient, remainder]
+
+    Example:
+    {[
+      let ct = Eqaf.divmod ~x ~m in
+      let not_ct = Int32.unsigned_div x m, Int32.unsigned_rem x m in
+      assert ct = not_ct ;
+    ]}
+
+    That is, an attacker might be able to learn [m] by measuring
+    execution time, but not the value of [x].
+
+    @raise Invalid_argument when [not (0 < m && m < 16384)].
+
+    @see "supercop/crypto_kem/sntrup761/ref/uint32.c" Adapted from the NTRU Prime team's algorithm from [supercop/sntrup761].
+*)
+
+(** {1:stringutil String utilities} *)
+
+(** {2 String search}*)
+
+val find_uint8 : ?off:int -> f:(int -> bool) -> string -> int
+(** [find_uint8 ?off ~f v] returns the index of the first occurrence which
+    respects the predicate [f] in string [v]. Otherwise, it returns [-1].
+    The caller is responsible for ensuring that [~f] operates in constant time.
+    The {!bool_of_int} function can be relevant when writing [~f] functions.
+*)
+
+val exists_uint8 : ?off:int -> f:(int -> bool) -> string -> bool
+(** [exists_uint8 ?off ~f v] tests if an occurrence respects the predicate
+    [f] in the string [v]. *)
+
+(** {2:ascii ASCII functions}*)
+
+val ascii_of_int32 : digits:int -> int32 -> string
+(** [ascii_of_int64 ~digits ~n] is a string consisting of
+    the rightmost [digits] characters of the decimal representation
+    of [n].
+    If [digits] is larger than the decimal representation, it is left-padded
+    with ['0'].
+    If [digits] is smaller, the output is truncated.
+
+    Example:
+    {[
+      let s1 = ascii_of_int64 ~digits:6 ~n:12345678L in
+      assert (s = "345678") ;
+      let s2 = ascii_of_int64 ~digits:6 ~n:1234L in
+      assert (s = "001234") ;
+    ]}
+
+    @raise Invalid_argument when [digits < 0]
+*)
+
+val lowercase_ascii : string -> string
+(** [lowercase_ascii str] is [str] where [A-Z] is replaced with [a-z].
+    It is a constant time implementation of {!String.lowercase_ascii}
+*)
+
+val uppercase_ascii : string -> string
+(** [uppercase_ascii str] is [str] where [a-z] is replaced with [A-Z].
+    It is a constant time implementation of {!String.uppercase_ascii}
+*)
+
+(** {2:hex Hex encoding and decoding}*)
+
+val hex_of_bytes : bytes -> string
+(** [hex_of_bytes raw] is [raw] hex-encoded in constant time.
+    Can be used to serialize sensitive values.
+    The {b contents can be secret}, but an attacker can learn the
+    {b length of} [raw] by timing this function.
+
+    Hex has two valid forms, lowercase and uppercase.
+    This function produces lowercase hex characters exclusively.
+
+    Example:
+    {[
+      let secret = "--Hi\x24" in
+      let serialized = hex_of_string secret in
+      (* serialized is now "2d2d486924" *)
+    ]}
+
+    @param raw is the source buffer. [raw] is not mutated by this function.
+*)
+
+val hex_of_string : string -> string
+(** [hex_of_string raw] is [hex_of_bytes raw] as a {!string} *)
+
+val bytes_of_hex : string -> bytes
+(** [bytes_of_hex hex] is [hex] decoded in constant time.
+    Can be used to e.g. decode secrets from configuration files.
+    The {b contents can be secret}, but an attacker can learn
+    the {b length of} [hex] by timing this function.
+
+    @param hex The hex-encoded octet string. Accepts characters [0-9 a-f A-F].
+    Note that [0x] prefixes or whitespace are not accepted.
+
+    @raise Invalid_argument When the length of [hex] is not a multiple of 2, or [hex] contains invalid characters.
+
+    Example:
+    {[
+      let serialized = "2d2d486924" in
+      let secret = string_of_hex serialized in
+      (* secret is now [--Hi$] *)
+    ]}
+*)
+
+val string_of_hex : string -> string
+(** [string_of_hex hex] is {!bytes_of_hex} [hex],
+    but returning a {!type:string} instead of {!type:bytes}.
+    @raise Invalid_argument When the length of [hex] is not a multiple of 2, or [hex] contains invalid characters.
+*)
+
+(** {1 Low-level primitives} *)
+
+(** {2 Bithacks} *)
 
 val one_if_not_zero : int -> int
 (** [one_if_not_zero n] is a constant-time version of
@@ -81,15 +219,94 @@ val zero_if_not_zero : int -> int
     [if n <> 0 then 0 else 1]. This is functionnaly equivalent to [!n] in the C
     programming language. *)
 
+val int_of_bool : bool -> int
+(** [int_of_bool b] is equivalent to [if b then 1 else 0].
+    Internally it cast with [%identity] instead of branching.*)
+
+val bool_of_int : int -> bool
+(** [bool_of_int n] is equivalent to [if n = 0 then false else true]. *)
+
+(** {2 Composition} *)
+
 val select_int : int -> int -> int -> int
 (** [select_int choose_b a b] is [a] if [choose_b = 0] and [b] otherwise.
     This comparison is constant-time and it should not be possible for a measuring
     adversary to determine anything about the values of [choose_b], [a], or [b]. *)
 
-val find_uint8 : ?off:int -> f:(int -> bool) -> string -> int
-(** [find_uint8 ?off ~f v] returns the index of the first occurrence which
-    respects the predicate [f] in string [v]. Otherwise, it returns [-1]. *)
+val select_a_if_in_range : low:int -> high:int ->
+  n:int -> int -> int -> int
+(** [select_a_if_in_range ~low ~high ~n a b]
+    - is [a] if [low <= n <= high] (in range)
+    - is [b] is [n < low || high < n] (out of range)
 
-val exists_uint8 : ?off:int -> f:(int -> bool) -> string -> bool
-(** [exists_uint8 ?off ~f v] tests if an occurrence respects the predicate
-    [f] in the string [v]. *)
+    This function {b only works for positive ranges}:
+    @param low  invariant: [0 <= low <= max_int]
+    @param high invariant: [low <= high <= max_int]
+
+    This function can be used like {!select_int} but using an integer range
+    instead of zero/non-zero to select.
+
+    It operates in constant time and is safe to use with secret parameters for
+    [low, high, n, a, b].
+
+    Example:
+    {[
+      let a = 123 and b = 456 in
+      let x = select_a_if_in_range ~low:10 ~high:20 ~n:10 a b in
+      (* x = 123 *)
+      let x = select_a_if_in_range ~low:10 ~high:20 ~n:0 a b in
+      (* x = 456 *)
+      let x = select_a_if_in_range ~low:10 ~high:20 ~n:20 a b in
+      (* x = 123 *)
+      let x = select_a_if_in_range ~low:10 ~high:20 ~n:21 a b in
+      (* x = 456 *)
+
+      (* Constant-time subpatterns can be expressed by nesting,
+         Below is a constant time version of:
+         match 3 with
+         | 1 | 2| 3 | 4 ->
+            begin match 3 with
+            | 2 | 3 -> 111
+            | _ -> 222
+            end
+         | _ -> 333
+
+      *)
+      let n = 3
+      select_a_if_in_range ~low:1 ~high:4 ~n
+        (select_a_if_in_range ~low:2 ~high:3 ~n
+           (111)
+           (222)
+        )
+        333
+      (* evalutes to 111 because [1 <= n  <= 4] selects the inner pattern
+         and [2 <= n <= 3] selects the first branch ("a") of the inner pattern.
+      *)
+
+      (* The applications can also be composed in constant time,
+         note that all the branches are always evaluated, so large
+         expressions can get slow:
+      *)
+      4
+      |> fun n -> select_a_if_in_range ~low:1 ~high:5 ~n
+         (n * 10)
+         (n - 100)
+      |> fun n -> select_a_if_in_range ~low:20 ~high 30 ~n
+         (n * 100)
+         (n+3)
+      (* evaluates to [4 *10 + 3] *)
+
+      (* Below the normal, non-constant time version: *)
+      4
+      |> (function
+           | n when 1 <= n && n <= 5 -> n * 10
+           | n -> n - 100)
+      |> (function
+          | n when 20 <= n && n <= 30 -> n * 100
+          | n -> n + 3)
+    ]}
+
+    Another example of how to use this can be found in the implementations of
+    {!lowercase_ascii} and {!bytes_of_hex}.
+*)
+

--- a/lib/eqaf.mli
+++ b/lib/eqaf.mli
@@ -107,7 +107,7 @@ val divmod : x:int32 -> m:int32 -> int32 * int32
 
     @raise Invalid_argument when [not (0 < m && m < 16384)].
 
-    @see "supercop/crypto_kem/sntrup761/ref/uint32.c" Adapted from the NTRU Prime team's algorithm from [supercop/sntrup761].
+    @see "supercop/crypto_kem/sntrup761/ref/uint32.c" Adapted from the NTRU Prime team's algorithm from [supercop/sntrup761], see round-2 NTRU Prime submission to NISTPQC (March 2019).
 *)
 
 (** {1:stringutil String utilities} *)

--- a/lib/eqaf.mli
+++ b/lib/eqaf.mli
@@ -180,29 +180,35 @@ val hex_of_bytes : bytes -> string
 val hex_of_string : string -> string
 (** [hex_of_string raw] is [hex_of_bytes raw] as a {!string} *)
 
-val bytes_of_hex : string -> bytes
-(** [bytes_of_hex hex] is [hex] decoded in constant time.
+val bytes_of_hex : string -> bytes * int
+(** [bytes_of_hex hex] is [raw, error] decoded in constant time.
     Can be used to e.g. decode secrets from configuration files.
     The {b contents can be secret}, but an attacker can learn
     the {b length of} [hex] by timing this function.
 
+    {b Error handling:} The second tuple element [error] is {b non-zero}
+    when the length of [hex] is not a multiple of 2,
+    or [hex] contains invalid characters.
+    Implementations should ensure that `error = 0` before using [raw].
+    The function signals errors this way to allow implementations to handle
+    invalid input errors in constant time.
+
     @param hex The hex-encoded octet string. Accepts characters [0-9 a-f A-F].
     Note that [0x] prefixes or whitespace are not accepted.
-
-    @raise Invalid_argument When the length of [hex] is not a multiple of 2, or [hex] contains invalid characters.
 
     Example:
     {[
       let serialized = "2d2d486924" in
-      let secret = string_of_hex serialized in
+      let secret, error = string_of_hex serialized in
+      assert (error = 0);
       (* secret is now [--Hi$] *)
     ]}
 *)
 
-val string_of_hex : string -> string
+val string_of_hex : string -> string * int
 (** [string_of_hex hex] is {!bytes_of_hex} [hex],
     but returning a {!type:string} instead of {!type:bytes}.
-    @raise Invalid_argument When the length of [hex] is not a multiple of 2, or [hex] contains invalid characters.
+    See {!bytes_of_hex} regarding handling of invalid input errors.
 *)
 
 (** {1 Low-level primitives} *)

--- a/lib/unsafe_pre407.ml
+++ b/lib/unsafe_pre407.ml
@@ -1,0 +1,13 @@
+external set_int32_ne : bytes -> int -> int32 -> unit = "%caml_string_set32"
+external get_int64_ne : bytes -> int -> int64 = "%caml_string_get64"
+
+external swap32 : int32 -> int32 = "%bswap_int32"
+external swap64 : int64 -> int64 = "%bswap_int64"
+
+let set_int32_le b i x =
+  if Sys.big_endian then set_int32_ne b i (swap32 x)
+  else set_int32_ne b i x
+
+let get_int64_le b i =
+  if Sys.big_endian then swap64 (get_int64_ne b i)
+  else get_int64_ne b i

--- a/lib/unsafe_pre408.ml
+++ b/lib/unsafe_pre408.ml
@@ -1,0 +1,13 @@
+external set_int32_ne : bytes -> int -> int32 -> unit = "%caml_bytes_set32"
+external get_int64_ne : bytes -> int -> int64 = "%caml_bytes_get64"
+
+external swap32 : int32 -> int32 = "%bswap_int32"
+external swap64 : int64 -> int64 = "%bswap_int64"
+
+let set_int32_le b i x =
+  if Sys.big_endian then set_int32_ne b i (swap32 x)
+  else set_int32_ne b i x
+
+let get_int64_le b i =
+  if Sys.big_endian then swap64 (get_int64_ne b i)
+  else get_int64_ne b i

--- a/lib/unsafe_stable.ml
+++ b/lib/unsafe_stable.ml
@@ -1,0 +1,2 @@
+let set_int32_le b i x = Bytes.set_int32_le b i x
+let get_int64_le b i = Bytes.get_int64_le b i

--- a/test/dune
+++ b/test/dune
@@ -5,6 +5,7 @@
 
 (rule
  (alias runtest)
+ (locks singleton)
  (deps
   (:test test.exe))
  (action
@@ -17,6 +18,7 @@
 
 (rule
  (alias runtest)
+ (locks singleton)
  (deps
   (:test test_branch.exe))
  (action

--- a/test/test.ml
+++ b/test/test.ml
@@ -32,6 +32,57 @@ let find str chr index =
   let res = Eqaf.find_uint8 ~f:((=) (Char.code chr)) str in
   Alcotest.(check int) "result" res index
 
+let select_a_if_in_range (low,high) n a b expect =
+  Alcotest.test_case
+    (Fmt.strf
+       "select_a_if_in_range (%d,%d) ~n:%d %d %d"
+       low high n a b
+    ) `Quick @@ fun ()->
+  let choice = Eqaf.select_a_if_in_range ~low ~high ~n a b in
+  Alcotest.(check int) "selected" expect choice
+
+let a_uint32 = Alcotest.testable Fmt.uint32 (=)
+
+
+let divmod str x m q r =
+  (* (x / m = q) and (x mod m = r) *)
+  Alcotest.test_case
+    (Fmt.strf
+       "divmod %s %lu / %lu = %lu, %lu mod %lu = %lu"
+       str x m q x m r
+    ) `Quick @@ fun ()->
+  let eq_quot, eq_rem = Eqaf.divmod ~x ~m in
+  Alcotest.(check (pair a_uint32 a_uint32)) "q,r" (q,r) (eq_quot,eq_rem)
+
+let ascii_of_int32 str digits n expect =
+  Alcotest.test_case
+    (Fmt.strf
+       "ascii_of_string %s %d %lu %S"
+       str digits n expect
+    ) `Quick @@ fun ()->
+  try
+    let ascii = Eqaf.ascii_of_int32 ~digits n in
+    Alcotest.(check string) str expect ascii
+  with Invalid_argument x when x = "digits < 0" -> ()
+
+let string_of_hex str hex expect =
+  Alcotest.test_case
+    (Fmt.strf
+       " %s %S %S"
+       str hex expect
+    ) `Quick @@ fun ()->
+  let enc = Eqaf.string_of_hex hex in
+  Alcotest.(check string) str expect enc
+
+let hex_of_string str raw expect =
+  Alcotest.test_case
+    (Fmt.strf
+       " %s %S %S"
+       str raw expect
+    ) `Quick @@ fun ()->
+  let enc = Eqaf.hex_of_string raw in
+  Alcotest.(check string) str expect enc
+
 let () =
   Alcotest.run "eqaf"
     [ "be", [ be "a" "a" 0
@@ -52,7 +103,7 @@ let () =
             ; le "bbb" "abc" (-1)
             ; le "bbb" "bbc" (-1)
             ; le "bbb" "abb" 1
-            ; le "\x00\x34\x12" "\x00\x33\x12" 1 
+            ; le "\x00\x34\x12" "\x00\x33\x12" 1
             ; le "\x00\x34\x12" "\x00\x33\x99" (-1) ]
     ; "exists", [ exists "a" 'a' true
                 ; exists "a" 'b' false
@@ -66,4 +117,71 @@ let () =
               ; find "bbbb" 'a' (-1)
               ; find "aabb" 'b' 2
               ; find "aabb" 'a' 0
-              ; find "aaab" 'b' 3 ] ]
+              ; find "aaab" 'b' 3 ]
+    ; "select_a_if_in_range",
+      [ select_a_if_in_range (0,3)   0 22 30 22
+      ; select_a_if_in_range (0,3)   1 22 30 22
+      ; select_a_if_in_range (0,3)   2 22 30 22
+      ; select_a_if_in_range (0,3)   3 22 30 22
+      ; select_a_if_in_range (0,3)   4 22 30 30
+      ; select_a_if_in_range (0,3) ~-1 22 30 30
+      ; select_a_if_in_range (0,0)   0 1 2 1
+      ; select_a_if_in_range (1,1)   0 3 4 4
+      ; select_a_if_in_range (1,1)   1 5 6 5
+      ; select_a_if_in_range (1,1)   2 7 8 8
+      ; select_a_if_in_range (0,0)   0 7904 0 7904
+      ; select_a_if_in_range (0,3) min_int 22 30 30
+      ; select_a_if_in_range (0,3) max_int 22 30 30
+      ; select_a_if_in_range (1,max_int-1) max_int 1 2 2
+      ; select_a_if_in_range (1,max_int-1) min_int 1 2 2
+      ; select_a_if_in_range (1,max_int-1) ~-1 3 4 4
+      ; select_a_if_in_range (1,max_int-1)   0 5 6 6
+      ; select_a_if_in_range (1,max_int) max_int 1 2 1
+      ; select_a_if_in_range (1,max_int) min_int 1 2 2
+      ; select_a_if_in_range (1,max_int) ~-1 3 4 4
+      ; select_a_if_in_range (1,max_int)   0 5 6 6
+      ; select_a_if_in_range (1,max_int)   1 5 6 5
+      ; select_a_if_in_range (0,max_int) max_int 1 2 1
+      ; select_a_if_in_range (0,max_int) min_int 1 2 2
+      ; select_a_if_in_range (0,max_int) ~-1 3 4 4
+      ; select_a_if_in_range (0,max_int)   0 5 6 5
+      ]
+    ; "divmod", [ divmod "" 1l 2l 0l 1l
+                ; divmod "" 123l 1l 123l 0l
+                ; divmod "" 1l 3l 0l 1l
+                ; divmod "" 2l 3l 0l 2l
+                ; divmod "" 3l 2l 1l 1l
+                ; divmod "" 10l 6l 1l 4l
+                ; divmod "" 10l 4l 2l 2l
+                ; divmod "" 1l 2l 0l 1l
+                ; divmod "" 30l 7l 4l 2l
+                ; divmod "" 4l 2l 2l 0l
+                ; divmod "" 1234567l 1l 1234567l 0l
+                ; divmod "" 1234567l 10l 123456l 7l
+                ; divmod "" 1234567l 100l 12345l 67l
+                ; divmod "" 1234567l 1000l 1234l 567l
+                ; divmod "" 1234567l 10000l 123l 4567l
+                ; divmod "" 12345l 100l 123l 45l
+                ; divmod "" 0xffff1234l  1_000_l 4294906l 420l
+                ; divmod "" 1123456789l 10_000_l 112345l 6789l ]
+    ; "ascii_of_int32", [ ascii_of_int32 ""  6  12345678l "345678"
+                        ; ascii_of_int32 "" ~-1     1234l "001234"
+                        ; ascii_of_int32 ""  1      9876l "6"
+                        ; ascii_of_int32 ""  4         0l "0000"
+                        ; ascii_of_int32 ""  6      1234l "001234"
+                        ; ascii_of_int32 ""  0      1234l ""]
+    ; "string_of_hex", [ string_of_hex "" "2d2d486924"  "--Hi$"
+                       ; string_of_hex "" "2D2d486924" "--Hi$"
+                       ; string_of_hex "" "1234" "\x12\x34"
+                       ; string_of_hex "" "ff80" "\xff\x80"
+                       ; string_of_hex "" "b7DDdd" "\xb7\xdd\xdd"
+                       ; string_of_hex "" "808888Fd" "\x80\x88\x88\xfd"
+                       ; string_of_hex "" "E0EE8eEEEE" "\xe0\xee\x8e\xee\xee"
+                       ; string_of_hex "empty" "" ""]
+    ; "hex_of_string", [ hex_of_string "" "--Hi$" "2d2d486924"
+                       ; hex_of_string "" "\x12\x34" "1234"
+                       ; hex_of_string "" "\xff\x80" "ff80"
+                       ; hex_of_string "" "\xb7\xff\x20" "b7ff20"
+                       ; hex_of_string "" "\x00\x01\x00" "000100"
+                       ; hex_of_string "empty" "" ""]
+    ]

--- a/test/test.ml
+++ b/test/test.ml
@@ -32,6 +32,20 @@ let find str chr index =
   let res = Eqaf.find_uint8 ~f:((=) (Char.code chr)) str in
   Alcotest.(check int) "result" res index
 
+let int_of_bool bool expect =
+  Alcotest.test_case
+    (Fmt.strf
+       "int_of_bool %B = %d" bool expect
+    ) `Quick @@ fun ()->
+  Alcotest.(check int) "result" expect (Eqaf.int_of_bool bool)
+
+let bool_of_int desc n expect =
+  Alcotest.test_case
+    (Fmt.strf
+       "int_of_bool %s = %B" desc expect
+    ) `Quick @@ fun ()->
+  Alcotest.(check bool) "result" expect (Eqaf.bool_of_int n)
+
 let select_a_if_in_range (low,high) n a b expect =
   Alcotest.test_case
     (Fmt.strf
@@ -118,6 +132,14 @@ let () =
               ; find "aabb" 'b' 2
               ; find "aabb" 'a' 0
               ; find "aaab" 'b' 3 ]
+    ; "int_of_bool", [ int_of_bool false 0 (* exhaustive :-) *)
+                     ; int_of_bool true  1]
+    ; "bool_of_int", [ bool_of_int "0" 0 false
+                     ; bool_of_int "-1" ~-1 true
+                     ; bool_of_int "2" 2 true
+                     ; bool_of_int "max_int" max_int true
+                     ; bool_of_int "min_int" min_int true
+                     ; bool_of_int "1" 1 true ]
     ; "select_a_if_in_range",
       [ select_a_if_in_range (0,3)   0 22 30 22
       ; select_a_if_in_range (0,3)   1 22 30 22

--- a/test/test.ml
+++ b/test/test.ml
@@ -86,7 +86,7 @@ let string_of_hex str hex expect =
        str hex expect
     ) `Quick @@ fun ()->
   let enc = Eqaf.string_of_hex hex in
-  Alcotest.(check string) str expect enc
+  Alcotest.(check @@ pair string int) str (expect,0) enc
 
 let hex_of_string str raw expect =
   Alcotest.test_case


### PR DESCRIPTION
I'm not married to any of these, but it was fun to implement them :-)
I'm happy to drop functionality if you don't think it belongs in `eqaf`.

This commit proposes a number of constant time utility functions:
- `divmod`, unsigned 32bit division with small divisors
- `ascii_of_int32`, conversion from `int32` to decimal `string` representation
- `select_a_if_in_range`, like `select_int` but *only* supporting positive ranges. In the future we can perhaps devise an algorithm to support arbitrary ranges.
- `lowercase_ascii` and `uppercase_ascii`, CT implementations of `String.(lowercase_ascii,uppercase_ascii` using `select_a_if_in_range`
- `hex_of_bytes` / `hex_of_string`, hex encoding
- `bytes_of_hex` / `string_of_hex`, hex decoding
- `bool_of_int` / `int_of_bool` (CT `Bool.to_int`) for constant time `bool`/`int` conversions

The doc generation with `dune build @doc` is also fixed to not generate errors, and `eqaf.mli` (the docs) were reorganized into sections to be easier to read.

The `README.md` was also slightly rewritten to document the existence of the other functions exposed by the library.

The additions are integrated with the fuzzing infrastructure, and have been tested with 300 million executions FWIW.