### PR TITLE
Remove execution of check/check.ml from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: avsm/setup-ocaml@v2
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 

--- a/check/dune
+++ b/check/dune
@@ -1,5 +1,6 @@
 (executable
  (name check)
+ (modules check linear_algebra benchmark fmt unsafe)
  (libraries eqaf base64 clock))
 
 (rule

--- a/check/dune
+++ b/check/dune
@@ -6,7 +6,7 @@
  (copy %{read:../config/which-unsafe-file} unsafe.ml))
 
 (rule
- (alias runtest)
+ (alias runbench)
  (deps
   (:check check.exe))
  (action


### PR DESCRIPTION
Even if we can run `check.exe` into the CI:
1) the result is volatile and depends on the execution context
2) we don't allow to merge as usual PRs and should run `check/check.exe` into a specific context
3) such specific context is hard to reproduce

For these points, I think it's _safe_ to discard for a release purpose the execution of `check.exe` and require such execution only when we want to improve `eqaf` (as @cfcs did in #26).