### PR TITLE
Fixes: FreeBSD support for clock (select), remove bigarray-compat depdency

### DIFF
--- a/clock/select/select.ml
+++ b/clock/select/select.ml
@@ -9,6 +9,8 @@ let load_file filename =
 
 let sexp_linux = "(-lrt)"
 
+let sexp_freebsd = "()"
+
 let sexp_windows = "()"
 
 let sexp_mach = "()"
@@ -22,6 +24,7 @@ let () =
             match system with
             | "linux" | "elf" -> `Linux
             | "windows" | "mingw64" | "mingw" | "cygwin" -> `Windows
+            | "freebsd" -> `FreeBSD
             | "macosx" -> `MacOSX
             | v ->
               if String.sub system 0 5 = "linux"
@@ -43,6 +46,10 @@ let () =
         ( load_file "clock_linux.ml"
         , load_file "clock_linux_stubs.c"
         , sexp_linux )
+    | `FreeBSD ->
+        ( load_file "clock_linux.ml"
+        , load_file "clock_linux_stubs.c"
+        , sexp_freebsd )
     | `Windows ->
         ( load_file "clock_windows.ml"
         , load_file "clock_windows_stubs.c"

--- a/eqaf.opam
+++ b/eqaf.opam
@@ -19,7 +19,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"          {>= "4.03.0"}
+  "ocaml"          {>= "4.07.0"}
   "dune"           {>= "2.0"}
   "base64"         {with-test}
   "alcotest"       {with-test}
@@ -28,7 +28,6 @@ depends: [
 
 depopts: [
   "cstruct"
-  "bigarray-compat"
 ]
 
 conflicts: [

--- a/lib/dune
+++ b/lib/dune
@@ -11,7 +11,7 @@
  (optional)
  (public_name eqaf.bigstring)
  (modules eqaf_bigstring)
- (libraries eqaf bigarray-compat))
+ (libraries eqaf))
 
 (library
  (name eqaf_cstruct)

--- a/lib/eqaf_bigstring.ml
+++ b/lib/eqaf_bigstring.ml
@@ -1,7 +1,7 @@
-type bigstring = (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+type bigstring = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-let length x = Bigarray_compat.Array1.dim x [@@inline]
-let get x i = Bigarray_compat.Array1.unsafe_get x i |> Char.code [@@inline]
+let length x = Bigarray.Array1.dim x [@@inline]
+let get x i = Bigarray.Array1.unsafe_get x i |> Char.code [@@inline]
 external unsafe_get_int16 : bigstring -> int -> int = "%caml_bigstring_get16u" [@@noalloc]
 let get16 x i = unsafe_get_int16 x i [@@inline]
 

--- a/lib/eqaf_bigstring.mli
+++ b/lib/eqaf_bigstring.mli
@@ -1,4 +1,4 @@
-type bigstring = (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+type bigstring = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 val equal : bigstring -> bigstring -> bool
 val compare_be : bigstring -> bigstring -> int


### PR DESCRIPTION
As proposed / discussed in #27. When this is fine to be merged, we can split into multiple packages.