### PR TITLE
Add support for current-bench

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version=0.18.0
+version=0.21.0
 disable=true

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 .PHONY: bench
 bench:
 	dune exec check/check.exe
+	dune exec check/bench.exe

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: bench
+bench:
+	dune exec check/check.exe

--- a/check/bench.ml
+++ b/check/bench.ml
@@ -1,0 +1,137 @@
+let seed = "4EygbdYh+v35vvrmD9YYP4byT5E3H7lTeXJiIj+dQnc="
+let seed = Base64.decode_exn seed
+
+let seed =
+  let res = Array.make (String.length seed / 2) 0 in
+  for i = 0 to (String.length seed / 2) - 1 do
+    res.(i) <- (Char.code seed.[i * 2] lsl 8) lor Char.code seed.[(i * 2) + 1]
+  done;
+  res
+
+let () =
+  let random_seed = seed in
+  Random.full_init random_seed
+
+let random length =
+  let get _ =
+    match Random.int (10 + 26 + 26) with
+    | n when n < 10 -> Char.(chr (code '0' + n))
+    | n when n < 10 + 26 -> Char.(chr (code 'a' + n - 10))
+    | n -> Char.(chr (code 'A' + n - 10 - 26))
+  in
+  String.init length get
+
+open Bechamel
+open Toolkit
+
+let hash_eq_0 = random 4096
+let hash_eq_1 = Bytes.to_string (Bytes.of_string hash_eq_0)
+let chr_into_hash_eq_0 = hash_eq_0.[Random.int 4096]
+let hash_neq_0 = random 4096
+
+let hash_neq_1 =
+  let rec go limit =
+    if limit <= 0 then failwith "Impossible to generate different hashes.";
+    let res = random 4096 in
+    if res = hash_neq_0 then go (pred limit) else res
+  in
+  go 10
+
+let random_chr =
+  let rec go limit =
+    if limit <= 0 then
+      failwith
+        "Impossible to generate a byte which does not appear into hash_neq_0.";
+    let res = Char.chr (Random.int 256) in
+    if not (String.contains hash_neq_0 res) then res else go (pred limit)
+  in
+  go 10
+
+let test_equal0 =
+  Test.make ~name:"equal"
+    (Staged.stage @@ fun () -> Eqaf.equal hash_eq_0 hash_eq_1)
+
+let test_equal1 =
+  Test.make ~name:"not equal"
+    (Staged.stage @@ fun () -> Eqaf.equal hash_neq_0 hash_neq_1)
+
+let cfg = Benchmark.cfg ~start:100
+
+let test_compare0 =
+  Test.make ~name:"equal"
+    (Staged.stage @@ fun () -> Eqaf.compare_be hash_eq_0 hash_eq_1)
+let test_compare1 =
+  Test.make ~name:"not equal"
+    (Staged.stage @@ fun () -> Eqaf.compare_be hash_neq_0 hash_neq_1)
+
+let f_eq_0 (v : int) = v = Char.code chr_into_hash_eq_0
+let f_neq_0 (v : int) = v = Char.code random_chr
+
+let test_exists0 =
+  Test.make ~name:"equal"
+    (Staged.stage @@ fun () -> Eqaf.exists_uint8 ~f:f_eq_0 hash_eq_0)
+let test_exists1 =
+  Test.make ~name:"not equal"
+    (Staged.stage @@ fun () -> Eqaf.exists_uint8 ~f:f_neq_0 hash_neq_0)
+
+let f_hash_eq_0 (v : int) = v = Char.code chr_into_hash_eq_0
+let f_random (v : int) = v = Char.code random_chr
+
+let test_find0 =
+  Test.make ~name:"equal"
+    (Staged.stage @@ fun () -> Eqaf.find_uint8 ~f:f_hash_eq_0 hash_eq_0)
+let test_find1 =
+  Test.make ~name:"not equal"
+    (Staged.stage @@ fun () -> Eqaf.find_uint8 ~f:f_random hash_neq_0)
+
+let benchmark () =
+  let ols =
+    Analyze.ols ~bootstrap:0 ~r_square:true ~predictors:Measure.[| run |]
+  in
+  let instances =
+    Instance.[ monotonic_clock ]
+  in
+  let cfg =
+    Benchmark.cfg ~limit:2000 ~stabilize:true ~quota:(Time.second 1.)
+      ~start:1000 ~kde:(Some 1000) ()
+  in
+  let test_equal =
+    Test.make_grouped ~name:"equal" ~fmt:"%s %s"
+      [ test_equal0; test_equal1 ]
+  in
+  let test_compare =
+    Test.make_grouped ~name:"compare" ~fmt:"%s %s"
+      [ test_compare0; test_compare1 ]
+  in
+  let test_exists =
+    Test.make_grouped ~name:"exists" ~fmt:"%s %s"
+      [ test_exists0; test_exists1 ]
+  in
+  let test_find =
+    Test.make_grouped ~name:"find" ~fmt:"%s %s"
+      [ test_find0; test_find1 ]
+  in
+  let raw_results =
+    Benchmark.all cfg instances
+      (Test.make_grouped ~name:"benchmark" ~fmt:"%s %s"
+         [ test_equal; test_compare; test_exists; test_find ])
+  in
+  let results =
+    List.map (fun instance -> Analyze.all ols instance raw_results) instances
+  in
+  let pr_bench name value =
+    Format.printf
+      {|{"results": [{"name": "eqaf", "metrics": [{"name": "%s", "value": %f, "units": "ns"}]}]}@.|}
+      name value
+  in
+  let results = Analyze.merge ols instances results in
+  let timings = Hashtbl.find results "monotonic-clock" in
+  Hashtbl.iter
+    (fun c v ->
+       match Analyze.OLS.estimates v with
+       | None -> ()
+       | Some ts -> List.iter (pr_bench c) ts)
+    timings;
+  ()
+
+let () = benchmark ()

--- a/check/check.ml
+++ b/check/check.ml
@@ -311,7 +311,11 @@ module Equal = Make(struct
   let reset = ignore and switch = ignore
 
   let stdlib_true () = String.equal hash_eq_0 hash_eq_1
-  let stdlib_false () = String.equal hash_neq_0 hash_neq_1
+  let stdlib_false () =
+    for _ = 1 to 100 do
+      let _ = String.equal hash_neq_0 hash_neq_1 in ()
+    done;
+    String.equal hash_neq_0 hash_neq_1
   
   let eqaf_true () = Eqaf.equal hash_eq_0 hash_eq_1
   let eqaf_false () = Eqaf.equal hash_neq_0 hash_neq_1
@@ -326,7 +330,11 @@ module Compare = Make(struct
   let reset = ignore and switch = ignore
 
   let stdlib_true () = String.compare hash_eq_0 hash_eq_1
-  let stdlib_false () = String.compare hash_neq_0 hash_neq_1
+  let stdlib_false () =
+    for _ = 1 to 100 do
+      let _ = String.compare hash_neq_0 hash_neq_1 in ()
+    done;
+    String.compare hash_neq_0 hash_neq_1
   
   let eqaf_true () = Eqaf.compare_be hash_eq_0 hash_eq_1
   let eqaf_false () = Eqaf.compare_be hash_neq_0 hash_neq_1

--- a/check/check.ml
+++ b/check/check.ml
@@ -312,11 +312,10 @@ module Equal = Make(struct
 
   let stdlib_true () = String.equal hash_eq_0 hash_eq_1
   let stdlib_false () =
-    for _ = 1 to 100 do
-      let _ = String.equal hash_neq_0 hash_neq_1 in ()
-    done;
+    for _ = 1 to 100
+    do let _ = String.equal hash_neq_0 hash_neq_1 in () done ;
     String.equal hash_neq_0 hash_neq_1
-  
+
   let eqaf_true () = Eqaf.equal hash_eq_0 hash_eq_1
   let eqaf_false () = Eqaf.equal hash_neq_0 hash_neq_1
 end)
@@ -331,9 +330,8 @@ module Compare = Make(struct
 
   let stdlib_true () = String.compare hash_eq_0 hash_eq_1
   let stdlib_false () =
-    for _ = 1 to 100 do
-      let _ = String.compare hash_neq_0 hash_neq_1 in ()
-    done;
+    for _ = 1 to 100
+    do let _ = String.compare hash_neq_0 hash_neq_1 in () done ;
     String.compare hash_neq_0 hash_neq_1
   
   let eqaf_true () = Eqaf.compare_be hash_eq_0 hash_eq_1
@@ -470,27 +468,21 @@ let () =
     if tried > 20 then invalid_arg "Too many tried for Eqaf.divmod" ;
     let res = Divmod32.test () in
     if res = exit_success then tried else _4 (succ tried) in
-
   let pr_bench name value = 
-    Fmt.pr {|{"results": [{"name": "eqaf", "metrics": [{"name": "%s", "value": %d}]}]}@.|} 
-      name value in
+    Fmt.pr {|{"results": [{"name": "check", "metrics": [{"name": "%s", "value": %d}]}]}@.|} name value in
   
   let _0 = _0 1 in
   Fmt.pr "%d trial(s) for Eqaf.equal.\n%!" _0 ;
   pr_bench "equal" _0 ;
-
   let _1 = _1 1 in
   Fmt.pr "%d trial(s) for Eqaf.compare.\n%!" _1 ;
   pr_bench "compare" _1 ;
-
   let _2 = _2 1 in
   Fmt.pr "%d trial(s) for Eqaf.exists.\n%!" _2 ;
   pr_bench "exists" _2 ;
-
   let _3 = _3 1 in
   Fmt.pr "%d trial(s) for Eqaf.find_uint8.\n%!" _3 ;
   pr_bench "find_uint8" _3 ;
-
   let _4 = _4 1 in
   Fmt.pr "%d trial(s) for Eqaf.divmod.\n%!" _4 ;
   pr_bench "divmod" _4 ;

--- a/check/check.ml
+++ b/check/check.ml
@@ -463,15 +463,28 @@ let () =
     let res = Divmod32.test () in
     if res = exit_success then tried else _4 (succ tried) in
 
+  let pr_bench name value = 
+    Fmt.pr {|{"results": [{"name": "eqaf", "metrics": [{"name": "%s", "value": %d}]}]}@.|} 
+      name value in
+  
   let _0 = _0 1 in
   Fmt.pr "%d trial(s) for Eqaf.equal.\n%!" _0 ;
+  pr_bench "equal" _0 ;
+
   let _1 = _1 1 in
   Fmt.pr "%d trial(s) for Eqaf.compare.\n%!" _1 ;
+  pr_bench "compare" _1 ;
+
   let _2 = _2 1 in
   Fmt.pr "%d trial(s) for Eqaf.exists.\n%!" _2 ;
+  pr_bench "exists" _2 ;
+
   let _3 = _3 1 in
   Fmt.pr "%d trial(s) for Eqaf.find_uint8.\n%!" _3 ;
+  pr_bench "find_uint8" _3 ;
+
   let _4 = _4 1 in
-  Fmt.pr "%d trial(s) for Eqaf.divmod.\n%!" _3 ;
+  Fmt.pr "%d trial(s) for Eqaf.divmod.\n%!" _4 ;
+  pr_bench "divmod" _4 ;
 
   exit exit_success

--- a/check/dune
+++ b/check/dune
@@ -3,6 +3,11 @@
  (modules check linear_algebra benchmark fmt unsafe)
  (libraries eqaf base64 clock))
 
+(executable
+ (name bench)
+ (modules bench)
+ (libraries bechamel eqaf base64))
+
 (rule
  (copy %{read:../config/which-unsafe-file} unsafe.ml))
 

--- a/eqaf.opam
+++ b/eqaf.opam
@@ -25,4 +25,5 @@ depends: [
   "alcotest"       {with-test}
   "crowbar"        {with-test}
   "fmt"            {with-test & >= "0.8.7"}
+  "bechamel"       {with-test}
 ]


### PR DESCRIPTION
The interest of this Pull request, which adds support for current-bench, is to monitor that eqaf operations continue to be resistant to timing attacks during the next Pull requests.

the integration with current-bench requires the installation of the GitHub application : https://github.com/marketplace/ocaml-benchmarks, on this repository, so that the tests are launched automatically after a pull request.

On which ocaml versions would you like to see the tests running?