### PR TITLE
Update system detection for monotonic clock

### DIFF
--- a/clock/select/select.ml
+++ b/clock/select/select.ml
@@ -26,6 +26,9 @@ let () =
             | "win32" | "win64" | "mingw64" | "mingw" | "cygwin" -> `Windows
             | "freebsd" -> `FreeBSD
             | "macosx" -> `MacOSX
+            | "beos" | "dragonfly" | "bsd" | "openbsd" | "netbsd" | "gnu"
+            | "solaris" | "unknown" ->
+              invalid_arg "Unsupported system: %s" system
             | v ->
               if String.sub system 0 5 = "linux"
               then `Linux

--- a/clock/select/select.ml
+++ b/clock/select/select.ml
@@ -23,7 +23,7 @@ let () =
           let system =
             match system with
             | "linux" | "elf" -> `Linux
-            | "windows" | "mingw64" | "mingw" | "cygwin" -> `Windows
+            | "win32" | "win64" | "mingw64" | "mingw" | "cygwin" -> `Windows
             | "freebsd" -> `FreeBSD
             | "macosx" -> `MacOSX
             | v ->


### PR DESCRIPTION
cf. mirage/bechamel#44.

- Use the correct values for the MSVC ports of OCaml (not tested; spotted that they're wrong as part of ocaml/ocaml#12405)
- Explicitly list the "known" OCaml system values